### PR TITLE
通信処理クラスの新規追加

### DIFF
--- a/hiragana/R.generated.swift
+++ b/hiragana/R.generated.swift
@@ -64,6 +64,24 @@ struct R: Rswift.Validatable {
     fileprivate init() {}
   }
   
+  /// This `R.string` struct is generated, and contains static references to 1 localization tables.
+  struct string {
+    /// This `R.string.ui` struct is generated, and contains static references to 1 localization keys.
+    struct ui {
+      /// Value: OK
+      static let btn_ok = Rswift.StringResource(key: "btn_ok", tableName: "ui", bundle: R.hostingBundle, locales: [], comment: nil)
+      
+      /// Value: OK
+      static func btn_ok(_: Void = ()) -> String {
+        return NSLocalizedString("btn_ok", tableName: "ui", bundle: R.hostingBundle, comment: "")
+      }
+      
+      fileprivate init() {}
+    }
+    
+    fileprivate init() {}
+  }
+  
   fileprivate struct intern: Rswift.Validatable {
     fileprivate static func validate() throws {
       try _R.validate()

--- a/hiragana/hiragana.xcodeproj/project.pbxproj
+++ b/hiragana/hiragana.xcodeproj/project.pbxproj
@@ -16,8 +16,13 @@
 		5450325322FAA65400C260DB /* hiraganaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450325222FAA65400C260DB /* hiraganaTests.swift */; };
 		5450325E22FAA65400C260DB /* hiraganaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450325D22FAA65400C260DB /* hiraganaUITests.swift */; };
 		546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */; };
+		546C760122FBF46C0070D3B7 /* HttpStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C760022FBF46C0070D3B7 /* HttpStatusCode.swift */; };
+		546C760322FC112D0070D3B7 /* HttpConnectionConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C760222FC112D0070D3B7 /* HttpConnectionConfig.swift */; };
+		546C760522FC148F0070D3B7 /* RequestMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C760422FC148F0070D3B7 /* RequestMethod.swift */; };
 		54F418A622FABC850047D943 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418A522FABC840047D943 /* R.generated.swift */; };
 		54F418A822FABF790047D943 /* ui.strings in Resources */ = {isa = PBXBuildFile; fileRef = 54F418A722FABF790047D943 /* ui.strings */; };
+		54F418B022FAD4660047D943 /* HttpConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418AF22FAD4660047D943 /* HttpConnection.swift */; };
+		54F418B222FAD48E0047D943 /* HttpConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418B122FAD48E0047D943 /* HttpConnectionDelegate.swift */; };
 		54F418B622FADD230047D943 /* JsonUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418B522FADD230047D943 /* JsonUtility.swift */; };
 		5DF8406337DA842871B54251 /* Pods_hiraganaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */; };
 		C01A8341525CD2F6E92BB14B /* Pods_hiraganaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DC3DAF8DB7852C6830F11DD /* Pods_hiraganaTests.framework */; };
@@ -56,8 +61,13 @@
 		5450325D22FAA65400C260DB /* hiraganaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hiraganaUITests.swift; sourceTree = "<group>"; };
 		5450325F22FAA65400C260DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
+		546C760022FBF46C0070D3B7 /* HttpStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpStatusCode.swift; sourceTree = "<group>"; };
+		546C760222FC112D0070D3B7 /* HttpConnectionConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnectionConfig.swift; sourceTree = "<group>"; };
+		546C760422FC148F0070D3B7 /* RequestMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMethod.swift; sourceTree = "<group>"; };
 		54F418A522FABC840047D943 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
 		54F418A722FABF790047D943 /* ui.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = ui.strings; sourceTree = "<group>"; };
+		54F418AF22FAD4660047D943 /* HttpConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnection.swift; sourceTree = "<group>"; };
+		54F418B122FAD48E0047D943 /* HttpConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpConnectionDelegate.swift; sourceTree = "<group>"; };
 		54F418B522FADD230047D943 /* JsonUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonUtility.swift; sourceTree = "<group>"; };
 		6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_hiraganaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		709AAA6F1D71AE5DAF1F4C31 /* Pods-hiraganaTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-hiraganaTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-hiraganaTests/Pods-hiraganaTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -178,7 +188,12 @@
 		54F418AE22FAD42F0047D943 /* HttpConnection */ = {
 			isa = PBXGroup;
 			children = (
+				54F418AF22FAD4660047D943 /* HttpConnection.swift */,
+				54F418B122FAD48E0047D943 /* HttpConnectionDelegate.swift */,
+				546C760222FC112D0070D3B7 /* HttpConnectionConfig.swift */,
 				54F418B522FADD230047D943 /* JsonUtility.swift */,
+				546C760422FC148F0070D3B7 /* RequestMethod.swift */,
+				546C760022FBF46C0070D3B7 /* HttpStatusCode.swift */,
 			);
 			path = HttpConnection;
 			sourceTree = "<group>";
@@ -440,11 +455,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				54F418B222FAD48E0047D943 /* HttpConnectionDelegate.swift in Sources */,
 				5450324022FAA65300C260DB /* ViewController.swift in Sources */,
 				5450323E22FAA65300C260DB /* AppDelegate.swift in Sources */,
 				546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */,
+				546C760322FC112D0070D3B7 /* HttpConnectionConfig.swift in Sources */,
 				54F418A622FABC850047D943 /* R.generated.swift in Sources */,
 				54F418B622FADD230047D943 /* JsonUtility.swift in Sources */,
+				546C760122FBF46C0070D3B7 /* HttpStatusCode.swift in Sources */,
+				546C760522FC148F0070D3B7 /* RequestMethod.swift in Sources */,
+				54F418B022FAD4660047D943 /* HttpConnection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/hiragana/hiragana.xcodeproj/project.pbxproj
+++ b/hiragana/hiragana.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		5450324822FAA65400C260DB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5450324622FAA65400C260DB /* LaunchScreen.storyboard */; };
 		5450325322FAA65400C260DB /* hiraganaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450325222FAA65400C260DB /* hiraganaTests.swift */; };
 		5450325E22FAA65400C260DB /* hiraganaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5450325D22FAA65400C260DB /* hiraganaUITests.swift */; };
+		546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */; };
 		54F418A622FABC850047D943 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418A522FABC840047D943 /* R.generated.swift */; };
 		54F418A822FABF790047D943 /* ui.strings in Resources */ = {isa = PBXBuildFile; fileRef = 54F418A722FABF790047D943 /* ui.strings */; };
 		5DF8406337DA842871B54251 /* Pods_hiraganaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */; };
@@ -53,6 +54,7 @@
 		5450325922FAA65400C260DB /* hiraganaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = hiraganaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5450325D22FAA65400C260DB /* hiraganaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hiraganaUITests.swift; sourceTree = "<group>"; };
 		5450325F22FAA65400C260DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
 		54F418A522FABC840047D943 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
 		54F418A722FABF790047D943 /* ui.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = ui.strings; sourceTree = "<group>"; };
 		6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_hiraganaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -139,6 +141,7 @@
 				54F418A522FABC840047D943 /* R.generated.swift */,
 				5450324922FAA65400C260DB /* Info.plist */,
 				54F418A722FABF790047D943 /* ui.strings */,
+				546C75FD22FBDEA60070D3B7 /* Extension */,
 			);
 			path = hiragana;
 			sourceTree = "<group>";
@@ -159,6 +162,14 @@
 				5450325F22FAA65400C260DB /* Info.plist */,
 			);
 			path = hiraganaUITests;
+			sourceTree = "<group>";
+		};
+		546C75FD22FBDEA60070D3B7 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 		753317E88118063439472512 /* Frameworks */ = {
@@ -420,6 +431,7 @@
 			files = (
 				5450324022FAA65300C260DB /* ViewController.swift in Sources */,
 				5450323E22FAA65300C260DB /* AppDelegate.swift in Sources */,
+				546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */,
 				54F418A622FABC850047D943 /* R.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/hiragana/hiragana.xcodeproj/project.pbxproj
+++ b/hiragana/hiragana.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */; };
 		54F418A622FABC850047D943 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418A522FABC840047D943 /* R.generated.swift */; };
 		54F418A822FABF790047D943 /* ui.strings in Resources */ = {isa = PBXBuildFile; fileRef = 54F418A722FABF790047D943 /* ui.strings */; };
+		54F418B622FADD230047D943 /* JsonUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F418B522FADD230047D943 /* JsonUtility.swift */; };
 		5DF8406337DA842871B54251 /* Pods_hiraganaUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */; };
 		C01A8341525CD2F6E92BB14B /* Pods_hiraganaTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DC3DAF8DB7852C6830F11DD /* Pods_hiraganaTests.framework */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,7 @@
 		546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
 		54F418A522FABC840047D943 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
 		54F418A722FABF790047D943 /* ui.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = ui.strings; sourceTree = "<group>"; };
+		54F418B522FADD230047D943 /* JsonUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonUtility.swift; sourceTree = "<group>"; };
 		6D8DEA5509AF99CACC3348DD /* Pods_hiraganaUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_hiraganaUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		709AAA6F1D71AE5DAF1F4C31 /* Pods-hiraganaTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-hiraganaTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-hiraganaTests/Pods-hiraganaTests.release.xcconfig"; sourceTree = "<group>"; };
 		8A751C98312D336652D49F60 /* Pods-hiragana.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-hiragana.debug.xcconfig"; path = "Pods/Target Support Files/Pods-hiragana/Pods-hiragana.debug.xcconfig"; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				54F418A522FABC840047D943 /* R.generated.swift */,
 				5450324922FAA65400C260DB /* Info.plist */,
 				54F418A722FABF790047D943 /* ui.strings */,
+				54F418AE22FAD42F0047D943 /* HttpConnection */,
 				546C75FD22FBDEA60070D3B7 /* Extension */,
 			);
 			path = hiragana;
@@ -170,6 +173,14 @@
 				546C75FE22FBDEBA0070D3B7 /* UIViewControllerExtension.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		54F418AE22FAD42F0047D943 /* HttpConnection */ = {
+			isa = PBXGroup;
+			children = (
+				54F418B522FADD230047D943 /* JsonUtility.swift */,
+			);
+			path = HttpConnection;
 			sourceTree = "<group>";
 		};
 		753317E88118063439472512 /* Frameworks */ = {
@@ -433,6 +444,7 @@
 				5450323E22FAA65300C260DB /* AppDelegate.swift in Sources */,
 				546C75FF22FBDEBA0070D3B7 /* UIViewControllerExtension.swift in Sources */,
 				54F418A622FABC850047D943 /* R.generated.swift in Sources */,
+				54F418B622FADD230047D943 /* JsonUtility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/hiragana/hiragana/Extension/UIViewControllerExtension.swift
+++ b/hiragana/hiragana/Extension/UIViewControllerExtension.swift
@@ -1,0 +1,71 @@
+//
+//  UIViewControllerExtension.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/08.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    /// ローディングインジケータ.
+    private static let indicator = UIActivityIndicatorView()
+    
+    /// インジケータ表示.
+    func showIndicator() {
+        if !view.subviews.contains(UIViewController.indicator) {
+            // インジケータの設定.
+            UIViewController.indicator.style = .gray
+            UIViewController.indicator.center = CGPoint(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY)
+            UIViewController.indicator.hidesWhenStopped = true
+            
+            // 画面に追加.
+            if !(view is UIVisualEffectView) {
+                view.addSubview(UIViewController.indicator)
+            }
+        }
+        
+        // 最前面に移動.
+        view.bringSubviewToFront(UIViewController.indicator)
+        
+        // アニメーション開始.
+        UIViewController.indicator.startAnimating()
+        // タップイベントを無効にする.
+        if !UIApplication.shared.isIgnoringInteractionEvents {
+            UIApplication.shared.beginIgnoringInteractionEvents()
+        }
+    }
+    
+    /// インジケータを非表示にする.
+    func hideIndicator() {
+        // アニメーション終了（自動非表示）.
+        UIViewController.indicator.stopAnimating()
+        // タップイベントを有効にする.
+        UIApplication.shared.endIgnoringInteractionEvents()
+    }
+    
+    
+    /// OKボタンのみのアラートを表示する.
+    ///
+    /// - Parameters:
+    ///   - title: ダイアログタイトル.
+    ///   - message: メッセージ.
+    ///   - onButtonTap: OKボタン押下時処理.
+    func showConfirmAlert(title: String, message: String, onButtonTap: (() -> Void)? = nil) {
+        // アラートを作成.
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        
+        // アラートにボタンをつける.
+        if let callback = onButtonTap {
+            alert.addAction(UIAlertAction(title: R.string.ui.btn_ok(), style: .default, handler: { _ in
+                callback()
+                }))
+        } else {
+            alert.addAction(UIAlertAction(title: R.string.ui.btn_ok(), style: .default))
+        }
+        
+        // アラート表示.
+        present(alert, animated: true, completion: nil)
+    }
+}

--- a/hiragana/hiragana/HttpConnection/HttpConnection.swift
+++ b/hiragana/hiragana/HttpConnection/HttpConnection.swift
@@ -1,0 +1,146 @@
+//
+//  HttpConnection.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/07.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+import UIKit
+
+/// HTTP通信クラス.
+class HttpConnection<T: Codable> {
+    var url: URL!
+    var delegate: HttpConnectionDelegate?
+    var config: HttpConnectionConfig?
+    var timeoutInterval = 8.0
+    private var retryCount = 0
+    
+    /// 接続する.
+    ///
+    /// - Parameter u: 接続するAPIのURL.
+    func connect(_ u: URL) {
+        url = u
+        
+        // queryString情報をconfigから取得して追加.
+        if let queryParameter = config?.queryParameter, retryCount == 0 {
+             url = URL(string: url.absoluteString + getQueryString(params: queryParameter))
+        }
+        
+        if let delegate = delegate {
+            // 接続前処理を実行.
+            delegate.onPreExecute(url: url)
+        }
+        
+        // リクエストを作成.
+        var request = URLRequest(url: url)
+        
+        request.timeoutInterval = timeoutInterval
+        request.httpMethod = config?.method.rawValue
+        
+        // ヘッダー情報をconfigから取得して追加.
+        if let headers = config?.header {
+            for header in headers {
+                request.addValue(header.value, forHTTPHeaderField: header.key)
+            }
+        }
+        
+        // requestBody情報をconfigから取得して追加.
+        if let requestBody = config?.requestBody {
+            request.httpBody = requestBody
+        }
+        
+        let task = URLSession.shared.dataTask(with: request, completionHandler: handleResult)
+        
+        task.resume()
+        
+        // 通信後処理.
+        if let delegate = delegate {
+            delegate.onPostExecute(url: url)
+        }
+    }
+    
+    /// 通信をリトライする.
+    private func retry() {
+        retryCount += 1
+        connect(url)
+    }
+    
+    /// 通信結果のハンドリング.
+    private func handleResult(apiData: Data?, response: URLResponse?, error: Error?) {
+        if let error = error {
+            // 失敗通知.
+            DispatchQueue.main.async {
+                // ネットワークに接続していない等のクライアント側エラー.
+                if let delegate = self.delegate {
+                    delegate.onFailure(error: error, retryCount: self.retryCount, retry: self.retry)
+                }
+            }
+            return
+        }
+        
+        guard let apiData = apiData, let response = response as? HTTPURLResponse else {
+            // 失敗通知.
+            DispatchQueue.main.async {
+                // レスポンスなし.
+                if let delegate = self.delegate {
+                    delegate.onFailure(error: URLError(.badServerResponse), retryCount: self.retryCount, retry: self.retry)
+                }
+            }
+            return
+        }
+        
+        if response.statusCode != HttpStatusCode.ok.rawValue {
+            // 失敗通知.
+            DispatchQueue.main.async {
+                // サーバ側エラー.
+                if let delegate = self.delegate {
+                    delegate.onFailure(error: URLError(URLError.Code(rawValue: response.statusCode)), retryCount: self.retryCount, retry: self.retry)
+                }
+            }
+            return
+        }
+        
+        let jsonStr: String = String(data: apiData, encoding: .utf8)!
+        
+        guard let data: T = JsonUtility.toObj(jsonStr: jsonStr) else {
+            DispatchQueue.main.async {
+                // 変換エラー(レスポンスの型違い).
+                if let delegate = self.delegate {
+                    delegate.onFailure(error: URLError(.cannotDecodeContentData), retryCount: self.retryCount, retry: self.retry)
+                }
+            }
+            return
+        }
+        
+        // 通常終了.
+        DispatchQueue.main.async {
+            if let delegate = self.delegate {
+                // 成功時デリゲートを実行.
+                delegate.onSuccess(response: data)
+            }
+        }
+    }
+    
+    /// クエリ文字列を作成する.
+    ///
+    /// - Parameter params: クエリ文字列に変換したいパラメータ.
+    private func getQueryString(params: [String: String]) -> String {
+        if params.count == 0 {
+            return ""
+        }
+        var queryString = "?"
+        var counter: Int = 0
+        for (key, value) in params {
+            queryString.append(key)
+            queryString.append("=")
+            queryString.append(value)
+            if counter < params.count - 1 {
+                // 要素が続く場合は&をつける
+                queryString.append("&")
+            }
+            counter += 1
+        }
+        return queryString
+    }
+}

--- a/hiragana/hiragana/HttpConnection/HttpConnectionConfig.swift
+++ b/hiragana/hiragana/HttpConnection/HttpConnectionConfig.swift
@@ -1,0 +1,47 @@
+//
+//  HttpConnectionConfig.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/08.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+import Foundation
+
+/// 通信の設定プロトコル.
+protocol HttpConnectionConfig {
+    /// ヘッダー.
+    var header: [String: String]? { get }
+    /// クエリパラメータ.
+    var queryParameter: [String: String]? { get }
+    /// リクエストボディ.
+    var requestBody: Data? { get }
+    /// リクエストのメソッド.
+    var method: RequestMethod { get }
+}
+
+extension HttpConnectionConfig {
+    var header: [String: String]? {
+        get {
+            return ["content-type": "application/json; charset=utf-8"]
+        }
+    }
+    
+    var queryParameter: [String: String]? {
+        get {
+            return nil
+        }
+    }
+    
+    var requestBody: Data? {
+        get {
+            return nil
+        }
+    }
+    
+    var method: RequestMethod {
+        get {
+            return .post
+        }
+    }
+}

--- a/hiragana/hiragana/HttpConnection/HttpConnectionDelegate.swift
+++ b/hiragana/hiragana/HttpConnection/HttpConnectionDelegate.swift
@@ -1,0 +1,60 @@
+//
+//  HttpConnectionDelegate.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/07.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// HTTP通信デリゲートプロトコル.
+protocol HttpConnectionDelegate {
+    /// 通信実行前処理.
+    /// デフォルトはログを吐くのみ.
+    ///
+    /// - Parameters:
+    ///   - url: アクセスするURL.
+    func onPreExecute(url: URL)
+    
+    /// 通信失敗時処理.
+    /// デフォルトはエラー内容をログに吐き、3回までリトライ.
+    ///
+    /// - Parameters:
+    ///   - error: エラーオブジェクト.
+    ///   - retryCount: リトライ回数.
+    ///   - retry: リトライ用デリゲート.
+    func onFailure(error: Error, retryCount: Int, retry: () -> Void)
+    
+    /// 通信成功時処理.
+    /// 必ず実装が必要.
+    ///
+    /// - Parameter response: オブジェクトに変換したレスポンス.
+    func onSuccess<T: Codable>(response: T)
+    
+    /// 通信実行後処理（失敗でも成功でも実行される）.
+    /// デフォルトはログを吐くのみ.
+    ///
+    /// - Parameters:
+    ///   - url: アクセスしたURL.
+    func onPostExecute(url: URL)
+}
+
+extension HttpConnectionDelegate {
+    func onPreExecute(url: URL) {
+        print("Start----- URL: \(url.absoluteString)")
+    }
+    
+    func onFailure(error: Error, retryCount: Int, retry: () -> Void) {
+        print(error.localizedDescription)
+        if retryCount >= 3 {
+            return
+        }
+        retry()
+    }
+    
+    func onPostExecute(url: URL) {
+        print("End----- URL: \(url.absoluteString)")
+    }
+}

--- a/hiragana/hiragana/HttpConnection/HttpStatusCode.swift
+++ b/hiragana/hiragana/HttpConnection/HttpStatusCode.swift
@@ -1,0 +1,276 @@
+//
+//  HttpStatusCode.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/08.
+//  Copyright © https://qiita.com/t_nagano/items/5c30c83270956f48a3aa
+//
+
+enum HttpStatusCode: Int {
+    
+    /*!
+     @brief 継続 クライアントはリクエストを継続できる。
+     */
+    case Continue = 100
+    
+    /*!
+     @brief プロトコル切り替え サーバはリクエストを理解し、遂行のためにプロトコルの切り替えを要求している
+     */
+    case switchingProtocols = 101
+    
+    /*!
+     @brief 処理中 WebDAVの拡張ステータスコード。処理が継続して行われていることを示す。
+     */
+    case processing = 102
+    
+    /*!
+     @brief OK リクエストは成功し、レスポンスとともに要求に応じた情報が返される。
+     */
+    case ok = 200
+    
+    /*!
+     @brief 作成 リクエストは完了し、新たに作成されたリソースのURIが返される。
+     */
+    case created = 201
+    
+    /*!
+     @brief 受理 リクエストは受理されたが、処理は完了していない。
+     */
+    case accepted = 202
+    
+    /*!
+     @brief 信頼できない情報 オリジナルのデータではなく、ローカルやプロキシ等からの情報であることを示す。
+     */
+    case nonAuthoritativeInformation = 203
+    
+    /*!
+     @brief 内容なし リクエストを受理したが、返すべきレスポンスエンティティが存在しない場合に返される。
+     */
+    case noContent = 204
+    
+    /*!
+     @brief 内容のリセット リクエストを受理し、ユーザエージェントの画面をリセットする場合に返される。
+     */
+    case resetContent = 205
+    
+    /*!
+     @brief 部分的内容 部分的GETリクエストを受理したときに、返される。
+     */
+    case partialContent = 206
+    
+    /*!
+     @brief 複数のステータス WebDAVの拡張ステータスコード。
+     */
+    case multiStatus = 207
+    
+    /*!
+     @brief IM使用 Delta encoding in HTTPの拡張ステータスコード。
+     */
+    case IMUsed = 226
+    
+    /*!
+     @brief 複数の選択 リクエストしたリソースが複数存在し、ユーザやユーザーエージェントに選択肢を提示するときに返される。
+     */
+    case multipleChoices = 300
+    
+    /*!
+     @brief 恒久的に移動した リクエストしたリソースが恒久的に移動されているときに返される。Location:ヘッダに移動先のURLが示されている。
+     */
+    case movedPermanently = 301
+    
+    /*!
+     @brief 発見した リクエストしたリソースが一時的に移動されているときに返される。Location:ヘッダに移動先のURLが示されている。
+     */
+    case found = 302
+    
+    /*!
+     @brief 他を参照せよ リクエストに対するレスポンスが他のURLに存在するときに返される。Location:ヘッダに移動先のURLが示されている。
+     */
+    case seeOther = 303
+    
+    /*!
+     @brief 未更新 リクエストしたリソースは更新されていないことを示す。
+     */
+    case notModified = 304
+    
+    /*!
+     @brief プロキシを使用せよ レスポンスのLocation:ヘッダに示されるプロキシを使用してリクエストを行わなければならないことを示す。
+     */
+    case useProxy = 305
+    
+    /*!
+     @brief 将来のために予約されている。ステータスコードは前のバージョンの仕様書では使われていたが、もはや使われておらず、将来のために予約されているとされる。
+     */
+    case unUsed = 306
+    
+    /*!
+     @brief 一時的リダイレクト リクエストしたリソースは一時的に移動されているときに返される。Location:ヘッダに移動先のURLが示されている。
+     */
+    case temporaryRedirect = 307
+    
+    /*!
+     @brief リクエストが不正である 定義されていないメソッドを使うなど、クライアントのリクエストがおかしい場合に返される。
+     */
+    case badRequest = 400
+    
+    /*!
+     @brief 認証が必要である Basic認証やDigest認証などを行うときに使用される。
+     */
+    case unauthorized = 401
+    
+    /*!
+     @brief 支払いが必要である 現在は実装されておらず、将来のために予約されているとされる。
+     */
+    case paymentRequired = 402
+    
+    /*!
+     @brief 禁止されている リソースにアクセスすることを拒否された。
+     */
+    case forbidden = 403
+    
+    /*!
+     @brief 未検出 リソースが見つからなかった。
+     */
+    case notFound = 404
+    
+    /*!
+     @brief 許可されていないメソッド 許可されていないメソッドを使用しようとした。
+     */
+    case methodNotAllowed = 405
+    
+    /*!
+     @brief 受理できない Accept関連のヘッダに受理できない内容が含まれている場合に返される。
+     */
+    case notAcceptable = 406
+    
+    /*!
+     @brief プロキシ認証が必要である プロキシの認証が必要な場合に返される。
+     */
+    case proxyAuthenticationRequired = 407
+    
+    /*!
+     @brief リクエストタイムアウト リクエストが時間以内に完了していない場合に返される。
+     */
+    case requestTimeout = 408
+    
+    /*!
+     @brief 矛盾 要求は現在のリソースと矛盾するので完了できない。
+     */
+    case conflict = 409
+    
+    /*!
+     @brief 消滅した。ファイルは恒久的に移動した。
+     */
+    case gone = 410
+    
+    /*!
+     @brief 長さが必要 Content-Lengthヘッダがないのでサーバーがアクセスを拒否した場合に返される。
+     */
+    case lengthRequired = 411
+    
+    /*!
+     @brief 前提条件で失敗した 前提条件が偽だった場合に返される。
+     */
+    case preconditionFailed = 412
+    
+    /*!
+     @brief リクエストエンティティが大きすぎる リクエストエンティティがサーバの許容範囲を超えている場合に返す。
+     */
+    case requestEntityTooLarge = 413
+    
+    /*!
+     @brief リクエストURIが大きすぎる URIが長過ぎるのでサーバが処理を拒否した場合に返す。
+     */
+    case requestURITooLong = 414
+    
+    /*!
+     @brief サポートしていないメディアタイプ 指定されたメディアタイプがサーバでサポートされていない場合に返す。
+     */
+    case unsupportedMediaType = 415
+    
+    /*!
+     @brief リクエストしたレンジは範囲外にある 実ファイルのサイズを超えるデータを要求した。
+     */
+    case requestedRangeNotSatisfiable = 416
+    
+    /*!
+     @brief Expectヘッダによる拡張が失敗 その拡張はレスポンスできない。またはプロキシサーバは、次に到達するサーバがレスポンスできないと判断している。
+     */
+    case expectationFailed = 417
+    
+    /*!
+     @brief 私はティーポット HTCPCP/1.0の拡張ステータスコード。
+     */
+    case imaTeapot = 418
+    
+    /*!
+     @brief 処理できないエンティティ WebDAVの拡張ステータスコード。
+     */
+    case unprocessableEntity = 422
+    
+    /*!
+     @brief ロックされている WebDAVの拡張ステータスコード。リクエストしたリソースがロックされている場合に返す。
+     */
+    case locked = 423
+    
+    /*!
+     @brief 依存関係で失敗 WebDAVの拡張ステータスコード。
+     */
+    case failedDependency = 424
+    
+    /*!
+     @brief アップグレード要求 Upgrading to TLS Within HTTP/1.1の拡張ステータスコード。
+     */
+    case upgradeRequired = 426
+    
+    /*!
+     @brief サーバ内部エラー サーバ内部にエラーが発生した場合に返される。
+     */
+    case internalServerError = 500
+    
+    /*!
+     @brief 実装されていない 実装されていないメソッドを使用した。
+     */
+    case notImplemented = 501
+    
+    /*!
+     @brief 不正なゲートウェイ ゲートウェイ・プロキシサーバは不正な要求を受け取り、これを拒否した。
+     */
+    case badGateway = 502
+    
+    /*!
+     @brief サービス利用不可 サービスが一時的に過負荷やメンテナンスで使用不可能である。
+     */
+    case serviceUnavailable = 503
+    
+    /*!
+     @brief ゲートウェイタイムアウト ゲートウェイ・プロキシサーバはURIから推測されるサーバからの適切なレスポンスがなくタイムアウトした。
+     */
+    case gatewayTimeout = 504
+    
+    /*!
+     @brief サポートしていないHTTPバージョン リクエストがサポートされていないHTTPバージョンである場合に返される。
+     */
+    case httpVersionNotSupported = 505
+    
+    /*!
+     @brief Transparent Content Negotiation in HTTPで定義されている拡張ステータスコード。
+     */
+    case variantAlsoNegotiates = 506
+    
+    /*!
+     @brief 容量不足 WebDAVの拡張ステータスコード。リクエストを処理するために必要なストレージの容量が足りない場合に返される。
+     */
+    case insufficientStorage = 507
+    
+    /*!
+     @brief 帯域幅制限超過 そのサーバに設定されている帯域幅（転送量）を使い切った場合に返される。
+     */
+    case bandwidthLimitExceeded = 509
+    
+    /*!
+     @brief 拡張できない An HTTP Extension Frameworkで定義されている拡張ステータスコード。
+     */
+    case notExtended = 510
+}
+

--- a/hiragana/hiragana/HttpConnection/JsonUtility.swift
+++ b/hiragana/hiragana/HttpConnection/JsonUtility.swift
@@ -1,0 +1,42 @@
+//
+//  JsonUtility.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/07.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+import Foundation
+
+/// Jsonを操作するユーティリティクラス.
+class JsonUtility {
+    
+    /// Json文字列から構造体に変換する.
+    /// 失敗するとnilを返す.
+    ///
+    /// - Parameter jsonStr: Json文字列.
+    /// - Returns: Jsonを変換したオブジェクト.
+    static func toObj<T: Codable>(jsonStr: String) -> T? {
+        // 文字列を目的のオブジェクト型に変換.
+        let decoder = JSONDecoder()
+        guard let data = try? decoder.decode(T?.self, from: jsonStr.data(using: .utf8)!) else {
+            return nil
+        }
+        
+        return data
+    }
+    
+    /// 構造体からJsonに変換する.
+    /// 失敗するとnilを返す.
+    ///
+    /// - Parameter data: 構造体のオブジェクト.
+    /// - Returns: オブジェクトを変換したJson.
+    static func toJson<T: Codable>(obj: T) -> Data? {
+        let encoder = JSONEncoder()
+        guard let json = try? encoder.encode(obj) else {
+            return nil
+        }
+        
+        return json
+    }
+}

--- a/hiragana/hiragana/HttpConnection/RequestMethod.swift
+++ b/hiragana/hiragana/HttpConnection/RequestMethod.swift
@@ -1,0 +1,16 @@
+//
+//  RequestMethod.swift
+//  hiragana
+//
+//  Created by 松原えりか on 2019/08/08.
+//  Copyright © 2019 松原えりか. All rights reserved.
+//
+
+/// リクエストメソッドの種類.
+enum RequestMethod: String {
+    case post   = "POST"
+    case get    = "GET"
+    case put    = "PUT"
+    case delete = "DELETE"
+    case patch  = "PATCH"
+}

--- a/hiragana/hiragana/ui.strings
+++ b/hiragana/hiragana/ui.strings
@@ -5,3 +5,6 @@
   Created by 松原えりか on 2019/08/07.
   Copyright © 2019 松原えりか. All rights reserved.
 */
+
+// ------ボタン------.
+"btn_ok" = "OK";


### PR DESCRIPTION
## 概要

通信処理に必要なクラスの追加

## 変更内容

- ダイアログ用の文字列リソース追加
- OKボタンのみのダイアログ表示メソッドをUIViewControllerに追加
- ローディングインジケータの表示/非表示メソッドをUIViewControllerに追加
- JSONを操作するためのユーティリティクラスの追加
- 通信処理本体のクラスを追加
- 通信処理のデリゲートプロトコルを追加
- 通信処理の設定プロトコルを追加

## 確認事項

### JsonUtility.swift
- [x] CodableとJSON文字列の相互変換ができること

### UIViewControllerExtension.swift
- [x] インジケータが表示, 非表示できること
- [x] アラートが表示できること

### その他
- [x] APIからレスポンスを取得できること
- [x] HttpConnectDelegateのメソッドが想定通りのタイミングで実行されること

## 注意事項

- コメントのCopyright欄にも記載していますが、HttpStatusCodeは[こちら](https://qiita.com/t_nagano/items/5c30c83270956f48a3aa)からいただきました