### PR TITLE
通信成功時にリトライカウントがリセットされないバグ修正

### DIFF
--- a/hiragana/hiragana/HttpConnection/HttpConnection.swift
+++ b/hiragana/hiragana/HttpConnection/HttpConnection.swift
@@ -120,6 +120,7 @@ class HttpConnection<T: Codable> {
                 delegate.onSuccess(response: data)
             }
         }
+        retryCount = 0
     }
     
     /// クエリ文字列を作成する.


### PR DESCRIPTION
## 概要

通信エラー発生後、通信に成功し、同じインスタンスを使って再度通信したときにリトライ回数がリセットされていないバグの修正

## 変更内容

- 通信成功時にretryCountを0にリセット